### PR TITLE
fix(footer): remove duplicate copyright notice

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -95,7 +95,7 @@
     </svg>
 
     <footer>
-        <p>&copy; <p>&copy; <script>document.write(new Date().getFullYear())</script> Hoboware</p> Hoboware</p>
+        <p>&copy; <script>document.write(new Date().getFullYear())</script> Hoboware</p>
     </footer>
 
     <script type="module" src="index.mjs"></script>


### PR DESCRIPTION
I tried to find the empty spot, but couldn't find it ;(

Tested it in different resolutions with noticeable colors, but all the layers seemed fine.
<img width="507" alt="Screenshot 2024-10-12 at 12 52 20" src="https://github.com/user-attachments/assets/3119fdaa-1121-492c-88cb-13c220fa0744">
