### PR TITLE
fix(footer): do not overlap description

### DIFF
--- a/src/lib/components/HoboFooter.svelte
+++ b/src/lib/components/HoboFooter.svelte
@@ -105,9 +105,15 @@
 		}
 	}
 
-	@media (max-aspect-ratio: 4/5) {
+	@media (max-aspect-ratio: 4/7) {
 		#hobo-footer {
 			width: 200vw;
+		}
+	}
+
+	@media (min-aspect-ratio: 4/7) and (max-aspect-ratio: 4/5) {
+		#hobo-footer {
+			width: 150vw;
 		}
 	}
 


### PR DESCRIPTION
## 👀 Example 👀
Before:
<img width="455" alt="before" src="https://github.com/user-attachments/assets/8c7333e7-71e6-493b-9cd6-b3e8f49ca474">

After:
<img width="455" alt="after" src="https://github.com/user-attachments/assets/71b32906-047a-41d1-8c4e-4da23436848a">
